### PR TITLE
Support alternative loggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
-        rails: ["6.1", "7.0"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        rails: ["6.1", "7.0", "7.1", "7.2"]
         continue-on-error: [false]
         exclude:
+          - ruby: "2.7"
+            rails: "7.1"
+          - ruby: "2.7"
+            rails: "7.2"
+          - ruby: "3.0"
+            rails: "7.1"
+          - ruby: "3.0"
+            rails: "7.2"
           - ruby: "3.2"
             rails: "6.1"
+          - ruby: "3.2"
+            rails: "6.1"
+          - ruby: "3.3"
+            rails: "6.1"
+          - ruby: "3.3"
+            rails: "6.1"
+
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
         ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
         rails: ["6.1", "7.0", "7.1", "7.2"]
         continue-on-error: [false]
+        include:
+          - ruby: "2.6"
+            rails: "5.2"
+          - ruby: "2.6"
+            rails: "6.0"
         exclude:
           - ruby: "2.7"
             rails: "7.1"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-rails_version = ENV.fetch("RAILS_VERSION", "7.0")
+rails_version = ENV.fetch("RAILS_VERSION", "7.2")
 
 if rails_version == "master"
   rails_constraint = { github: "rails/rails" }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JsonTaggedLogger
 
 [![Build Status](https://github.com/santry/json_tagged_logger/actions/workflows/ci.yml/badge.svg)](https://github.com/santry/json_tagged_logger/actions/workflows/ci.yml)
+[![Gem Version](https://badge.fury.io/rb/json_tagged_logger.svg)](https://badge.fury.io/rb/json_tagged_logger)
 
 `JsonTaggedLogger` works in conjunction with [`ActiveSupport::TaggedLogging`](https://api.rubyonrails.org/classes/ActiveSupport/TaggedLogging.html) and (optionally) [Lograge](https://github.com/roidrage/lograge) to produce JSON-formatted log output. By itself, `ActiveSupport::TaggedLogging` supports simple tagging. With `JsonTaggedLogger`, you can compose key/value pairs, simple tags, and the log message itself into a single JSON document for easy consumption and parsing in log aggregators.
 

--- a/json_tagged_logger.gemspec
+++ b/json_tagged_logger.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '>= 5.16'
   s.add_development_dependency 'rake', '>= 13.0'
 
-  s.add_runtime_dependency 'activesupport', '>= 6.1'
-  s.add_runtime_dependency 'actionpack', '>= 6.1'
+  s.add_runtime_dependency 'activesupport', '>= 5.2'
+  s.add_runtime_dependency 'actionpack', '>= 5.2'
 
-  s.required_ruby_version = '>= 2.7'
+  s.required_ruby_version = '>= 2.6'
 end

--- a/lib/json_tagged_logger/formatter.rb
+++ b/lib/json_tagged_logger/formatter.rb
@@ -22,7 +22,7 @@ module JsonTaggedLogger
         log[:tags] = text_tags.to_a
       end
 
-      bare_message = message_without_tags(message)
+      bare_message = message_without_tags(message.to_s)
 
       begin
         parsed_message = JSON.parse(bare_message)

--- a/lib/json_tagged_logger/formatter.rb
+++ b/lib/json_tagged_logger/formatter.rb
@@ -1,8 +1,11 @@
 require 'active_support/core_ext/hash/keys'
+require 'active_support/tagged_logging'
 require 'json'
 
 module JsonTaggedLogger
   class Formatter
+    include ActiveSupport::TaggedLogging::Formatter
+
     attr_accessor :pretty_print
 
     def initialize(pretty_print: false)

--- a/lib/json_tagged_logger/formatter.rb
+++ b/lib/json_tagged_logger/formatter.rb
@@ -1,5 +1,5 @@
+require 'active_support'
 require 'active_support/core_ext/hash/keys'
-require 'active_support/tagged_logging'
 require 'json'
 
 module JsonTaggedLogger

--- a/lib/json_tagged_logger/logger.rb
+++ b/lib/json_tagged_logger/logger.rb
@@ -4,8 +4,23 @@ require 'active_support/tagged_logging'
 module JsonTaggedLogger
   module Logger
     def self.new(logger, pretty_print: false)
-      logger.formatter = Formatter.new(pretty_print: pretty_print)
-      ActiveSupport::TaggedLogging.new(logger)
+      logger = logger.clone
+      logger.formatter =  JsonTaggedLogger::Formatter.new(pretty_print: pretty_print)
+      logger.extend(self)
     end
+
+    delegate :push_tags, :pop_tags, :clear_tags!, to: :formatter
+
+    def tagged(*tags)
+      if block_given?
+        formatter.tagged(*tags) { yield self }
+      else
+        logger = JsonTaggedLogger::Logger.new(self)
+        logger.formatter = JsonTaggedLogger::Formatter.new
+        logger.push_tags(*formatter.current_tags, *tags)
+        logger
+      end
+    end
+
   end
 end

--- a/lib/json_tagged_logger/logger.rb
+++ b/lib/json_tagged_logger/logger.rb
@@ -1,5 +1,4 @@
 require 'active_support'
-require 'active_support/tagged_logging'
 
 module JsonTaggedLogger
   module Logger

--- a/lib/json_tagged_logger/version.rb
+++ b/lib/json_tagged_logger/version.rb
@@ -1,3 +1,3 @@
 module JsonTaggedLogger
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
- e.g. https://github.com/pboling/activesupport-tagged_logging

Since Rails uses autoloading, there is no need to explicitly require `active_support/tagged_logging`, and doing so actively prevents using an alternative.

I have created a suite of gems that replace the Rails logger.  They extract the logging tooling from Rails 8, add in some refactoring and fixes that allow broadcasting, tagged logging, and blocks, to all work together, (which bugs have *always* been present in tagged logging, and remain in v8.0, see [Rails PR 53093][pr-53093] and [Rails PR 53105][pr-53105]).

It works with Rails _because_ of the autoloading.  If a namespace / constant is already defined, it won't go looking for it.  So by defining it in my extracted gems, the vanilla (broken) Rails version doesn't load.

At that point the only problem comes from libraries which load certain Rails internals explicitly.

The suite of gems I'm aiming to have compatibility with is:

- Enhanced [activesupport-logger][activesupport-logger] which was ripped from Rails v8.0
- Enhanced [activesupport-broadcast_logger][activesupport-broadcast_logger] which was ripped from Rails v8.0, and [this PR][pr-53093]
- Enhanced [activesupport-tagged_logging][activesupport-tagged_logging] which was ripped from Rails v8.0, and [this PR][pr-53105]

[activesupport-logger]: https://github.com/pboling/activesupport-logger
[activesupport-broadcast_logger]: https://github.com/pboling/activesupport-broadcast_logger
[activesupport-tagged_logging]: https://github.com/pboling/activesupport-tagged_logging
[pr-53105]: https://github.com/rails/rails/pull/53105
[pr-53093]: https://github.com/rails/rails/pull/53093
